### PR TITLE
Upgrade docker images to v2.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BRANCH=v2.0-beta3
+ARG BRANCH=v2.0.1
 ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
 RUN wget -q -O - "${URL}" | tar xz \
   && ln -s netbox* netbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BRANCH=v2-beta
+ARG BRANCH=v2.0-beta3
 ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
 RUN wget -q -O - "${URL}" | tar xz \
   && ln -s netbox* netbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BRANCH=v2.0.1
+ARG BRANCH=v2.0.7
 ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
 RUN wget -q -O - "${URL}" | tar xz \
   && ln -s netbox* netbox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     netbox:
         build: .
-        image: digitalocean/netbox:v2.0-beta3
+        image: digitalocean/netbox:v2.0.1
         depends_on:
         - postgres
         env_file: netbox.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     netbox:
         build: .
-        image: digitalocean/netbox:v2.0-beta2
+        image: digitalocean/netbox:v2.0-beta3
         depends_on:
         - postgres
         env_file: netbox.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     netbox:
         build: .
-        image: digitalocean/netbox:v2.0.1
+        image: digitalocean/netbox:v2.0.7
         depends_on:
         - postgres
         env_file: netbox.env


### PR DESCRIPTION
This upgrades the docker image past the [previous 2.x update](https://github.com/digitalocean/netbox-docker/pull/7) (which hasn't been merged yet). 

I'm having some issues building this, but I think it's [due to an older docker version I'm on](https://github.com/moby/moby/issues/20789). 