### PR TITLE
Fix an error in the Dockerfile and point at the current beta release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/* eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
-ARG BRANCH=v2-beta
+ARG BRANCH=v2.2-beta1
 ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
 RUN wget -q -O - "${URL}" | tar xz \
   && ln -s netbox* netbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN ln -s configuration.docker.py netbox/netbox/configuration.py
 COPY docker/gunicorn_config.py /opt/netbox/
 
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker/nginx.conf /etc/netbox-nginx/
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 VOLUME ["/etc/netbox-nginx/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     netbox:
         build: .
-        image: digitalocean/netbox:v2.0-beta2
+        image: digitalocean/netbox:v2.2-beta1
         depends_on:
         - postgres
         env_file: netbox.env


### PR DESCRIPTION
Docker compose didn't work, as the nginx config was not being copied into the Netbox docker image.

These commits also add a gitattributes file to enforce unix line endings on files that will be copied into containers (supporting docker for windows), and bump to the current beta release (which looks really cool!)
