### PR TITLE
use python:2.7-alpine3.6 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine
+FROM python:2.7-alpine3.6
 
 RUN apk add --no-cache \
       bash \
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
       libxml2-dev \
       libxslt-dev \
       openldap-dev \
-      openssl-dev \
+      libressl-dev \
       postgresql-dev \
       wget \
   && pip install gunicorn==17.5 django-auth-ldap


### PR DESCRIPTION
This works around a known issue in docker-alpine 3.4,
which python:2.7-alpine is based on.
openssl causes dependency conflicts, so swapped out for libressl.

See: gliderlabs/docker-alpine#231